### PR TITLE
Guard transform sheet warnings against missing sources

### DIFF
--- a/excel_processing.py
+++ b/excel_processing.py
@@ -554,6 +554,62 @@ class ExcelApp:
             self._format_cache[key] = workbook.add_format(fmt_dict)
         return self._format_cache[key]
 
+    def _process_insert_positions(
+        self,
+        template_rows,
+        base_insert_positions,
+        source_sheet_list,
+        source_data,
+        target_sheet_name
+    ):
+        """根據插入點將來源資料插入模板列中。"""
+        new_sheet_rows = template_rows.copy()
+        offset = 0
+        status_cb = getattr(self, "status_callback", None)
+
+        for pos_idx, base_pos in enumerate(base_insert_positions):
+            start_msg = f"開始處理插入點，pos_idx ={pos_idx}"
+            print(start_msg)
+            if status_cb:
+                status_cb(start_msg)
+
+            source_sheet_name = (
+                source_sheet_list[pos_idx]
+                if pos_idx < len(source_sheet_list)
+                else None
+            )
+            source_label = source_sheet_name or f"{target_sheet_name}#{pos_idx + 1}"
+
+            try:
+                if source_sheet_name and source_sheet_name in source_data:
+                    data = source_data[source_sheet_name]
+                    num_data_rows = data.shape[0]
+                    data_rows = [list(data.iloc[i]) for i in range(num_data_rows)]
+
+                    # 原本預留◎符號所在列及其後兩列，共 3 列
+                    insert_index = base_pos + 3 + offset
+
+                    # 插入來源資料，將 data_rows 這個清單插入到 new_sheet_rows 的指定位置
+                    new_sheet_rows[insert_index:insert_index] = data_rows
+                    offset += num_data_rows
+                    print(
+                        f"在 {target_sheet_name} 的索引 {insert_index} 插入 {num_data_rows} 行來源資料"
+                    )
+                else:
+                    warn_msg = (
+                        f"模板中無對應來源資料，目標 {target_sheet_name} 插入點 {pos_idx + 1} 將略過（{source_label}）。"
+                    )
+                    print(warn_msg)
+                    if status_cb:
+                        status_cb(warn_msg)
+            except Exception as e:
+                err_msg = f"無法處理 {source_label} 工作表：{e}"
+                print(err_msg)
+                if status_cb:
+                    status_cb(err_msg)
+
+        return new_sheet_rows
+
     def transform_sheet(self):
         """
         將原始 Excel 表單轉換成盤查表單格式：
@@ -569,9 +625,12 @@ class ExcelApp:
         if not self.file_path:
             messagebox.showerror("錯誤", "請選擇 Excel 文件")
             return
-        
+
         ok = False
         err_msg = None
+        wb_tpl = None
+        wb_new = None
+        excel = None
         try:
             self._format_cache.clear()  # 清空格式快取
             self.status_callback("開始執行 Transform Sheet")
@@ -684,33 +743,15 @@ class ExcelApp:
                     if any(cell is not None and '◎' in str(cell) for cell in row):
                         base_insert_positions.append(idx)
                         print(f"在 {target_sheet_name} 模板中找到插入點：第 {idx} 行")
-                
+
                 # 複製模板內容作為最終輸出，並利用 offset 追蹤因插入或替換而產生的行偏移
-                new_sheet_rows = template_rows.copy()
-                offset = 0
-
-
-                for pos_idx, base_pos in enumerate(base_insert_positions):
-                    print("開始處理插入點，pos_idx =", pos_idx)
-                    self.status_callback(f"開始處理插入點，pos_idx ={pos_idx}")
-                    try:
-                        if pos_idx < len(source_sheet_list):
-                            sheet_name = source_sheet_list[pos_idx]
-                            data = source_data[sheet_name]
-                            num_data_rows = data.shape[0]
-                            data_rows = [list(data.iloc[i]) for i in range(num_data_rows)]
-                            
-                            # 原本預留◎符號所在列及其後兩列，共 3 列
-                            insert_index = base_pos + 3 + offset
-
-                            # 插入來源資料，將 data_rows 這個清單「插入」到 new_sheet_rows 的指定位置
-                            new_sheet_rows[insert_index:insert_index] = data_rows   #「從第 insert_index 個元素開始，到第 insert_index 個元素結束」
-                            offset += num_data_rows
-                            print(f"在 {target_sheet_name} 的索引 {insert_index} 插入 {num_data_rows} 行來源資料")
-                        else:
-                            print(f"模板中無對應來源資料，無法插入 {sheet_name} 的資料")
-                    except Exception as e:
-                        print(f"無法處理 {sheet_name} 工作表：{e}")
+                new_sheet_rows = self._process_insert_positions(
+                    template_rows,
+                    base_insert_positions,
+                    source_sheet_list,
+                    source_data,
+                    target_sheet_name
+                )
 
                 default_format = [cell_info["format"] for cell_info in format_definitions[target_sheet_name][4]]
                 self._fallback_fmt = workbook.add_format({

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test_*.py

--- a/tests/test_excel_processing.py
+++ b/tests/test_excel_processing.py
@@ -1,0 +1,185 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class DummyDataFrame:
+    def __init__(self, rows):
+        self._rows = rows
+
+    class _ILoc:
+        def __init__(self, outer):
+            self._outer = outer
+
+        def __getitem__(self, idx):
+            return list(self._outer._rows[idx])
+
+    @property
+    def iloc(self):
+        return DummyDataFrame._ILoc(self)
+
+    @property
+    def shape(self):
+        if not self._rows:
+            return (0, 0)
+        return (len(self._rows), len(self._rows[0]))
+
+    def replace(self, *args, **kwargs):
+        return self
+
+    def fillna(self, *args, **kwargs):
+        return self
+
+
+docx_module = types.ModuleType("docx")
+docx_module.Document = object
+sys.modules.setdefault("docx", docx_module)
+
+docx_shared_module = types.ModuleType("docx.shared")
+docx_shared_module.Inches = lambda *args, **kwargs: None
+sys.modules.setdefault("docx.shared", docx_shared_module)
+
+docxtpl_module = types.ModuleType("docxtpl")
+docxtpl_module.DocxTemplate = object
+docxtpl_module.InlineImage = object
+sys.modules.setdefault("docxtpl", docxtpl_module)
+
+openpyxl_module = types.ModuleType("openpyxl")
+openpyxl_module.load_workbook = lambda *args, **kwargs: None
+sys.modules.setdefault("openpyxl", openpyxl_module)
+
+openpyxl_styles_module = types.ModuleType("openpyxl.styles")
+sys.modules.setdefault("openpyxl.styles", openpyxl_styles_module)
+
+openpyxl_colors_module = types.ModuleType("openpyxl.styles.colors")
+
+
+class _Color:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+openpyxl_colors_module.Color = _Color
+sys.modules.setdefault("openpyxl.styles.colors", openpyxl_colors_module)
+
+matplotlib_module = types.ModuleType("matplotlib")
+matplotlib_pyplot_module = types.ModuleType("matplotlib.pyplot")
+matplotlib_pyplot_module.figure = lambda *args, **kwargs: None
+matplotlib_pyplot_module.plot = lambda *args, **kwargs: None
+matplotlib_pyplot_module.close = lambda *args, **kwargs: None
+matplotlib_module.pyplot = matplotlib_pyplot_module
+sys.modules.setdefault("matplotlib", matplotlib_module)
+sys.modules.setdefault("matplotlib.pyplot", matplotlib_pyplot_module)
+
+pseudo_numpy = types.ModuleType("numpy")
+pseudo_numpy.inf = float("inf")
+pseudo_numpy.nan = float("nan")
+sys.modules.setdefault("numpy", pseudo_numpy)
+
+pandas_module = types.ModuleType("pandas")
+pandas_module.DataFrame = DummyDataFrame
+pandas_module.read_excel = lambda *args, **kwargs: DummyDataFrame([])
+sys.modules.setdefault("pandas", pandas_module)
+
+xlsxwriter_module = types.ModuleType("xlsxwriter")
+
+
+class _DummyWorkbook:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def add_worksheet(self, *args, **kwargs):
+        return object()
+
+    def add_format(self, fmt):
+        return fmt
+
+    def close(self):
+        pass
+
+
+xlsxwriter_module.Workbook = _DummyWorkbook
+sys.modules.setdefault("xlsxwriter", xlsxwriter_module)
+
+pythoncom_module = types.ModuleType("pythoncom")
+pythoncom_module.CoInitialize = lambda *args, **kwargs: None
+pythoncom_module.CoUninitialize = lambda *args, **kwargs: None
+sys.modules.setdefault("pythoncom", pythoncom_module)
+
+win32com_module = types.ModuleType("win32com")
+win32com_client_module = types.ModuleType("win32com.client")
+
+
+class _DummyDispatch:
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
+win32com_client_module.DispatchEx = lambda *args, **kwargs: _DummyDispatch()
+win32com_module.client = win32com_client_module
+sys.modules.setdefault("win32com", win32com_module)
+sys.modules.setdefault("win32com.client", win32com_client_module)
+
+
+from excel_processing import ExcelApp
+
+
+def test_process_insert_positions_skips_when_template_has_extra_placeholders(capsys):
+    app = ExcelApp()
+
+    template_rows = [
+        [{"value": "◎", "format": {}}],
+        [{"value": "header", "format": {}}],
+        [{"value": "◎", "format": {}}],
+        [{"value": "footer", "format": {}}],
+        [{"value": "end", "format": {}}],
+    ]
+    base_insert_positions = [0, 2]
+    source_sheet_list = ["SourceA"]
+    source_data = {"SourceA": DummyDataFrame([["row-data"]])}
+
+    result_rows = app._process_insert_positions(
+        template_rows,
+        base_insert_positions,
+        source_sheet_list,
+        source_data,
+        "Raw Material",
+    )
+
+    assert len(result_rows) == len(template_rows) + 1
+    assert result_rows[3] == ["row-data"]
+
+    captured = capsys.readouterr()
+    assert "Raw Material" in captured.out
+    assert "略過" in captured.out or "無對應來源資料" in captured.out
+
+
+def test_process_insert_positions_warns_with_fallback_name(capsys):
+    app = ExcelApp()
+
+    template_rows = [
+        [{"value": "◎", "format": {}}],
+        [{"value": "◎", "format": {}}],
+        [{"value": "end", "format": {}}],
+    ]
+    base_insert_positions = [0, 1]
+    source_sheet_list = ["SourceA"]
+    source_data = {"SourceA": DummyDataFrame([["row-data"]])}
+
+    result_rows = app._process_insert_positions(
+        template_rows,
+        base_insert_positions,
+        source_sheet_list,
+        source_data,
+        "Raw Material",
+    )
+
+    assert len(result_rows) == len(template_rows) + 1
+
+    captured = capsys.readouterr()
+    assert "Raw Material#2" in captured.out
+    assert "略過" in captured.out or "無對應來源資料" in captured.out


### PR DESCRIPTION
## Summary
- ensure transform sheet placeholder logging uses the safe target or fallback name
- update exception messaging to reference guarded labels
- add a regression test that confirms extra template placeholders only trigger warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df62cd2934832b8151938241e72900